### PR TITLE
ci: use version tag refs for reusable workflows

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -8,23 +8,23 @@ on:
 
 jobs:
   build-and-push:
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@v0.1.0
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@v1.1.1
   security-scan:
     needs: [build-and-push]
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@v0.1.0
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@v1.1.1
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   policy-verification:
     needs:
       - build-and-push
       - security-scan
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@v0.1.0
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@v1.1.1
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   deploy:
     needs:
       - build-and-push
       - policy-verification
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@v0.1.0
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@v1.1.1
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -3,27 +3,28 @@ on:
   push:
     branches:
       - main
+      - refactor-identities
   workflow_dispatch:
 
 jobs:
   build-and-push:
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@main
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@refactor-identities
   security-scan:
     needs: [build-and-push]
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@main
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@refactor-identities
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   policy-verification:
     needs:
       - build-and-push
       - security-scan
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@main
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@refactor-identities
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   deploy:
     needs:
       - build-and-push
       - policy-verification
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@main
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@refactor-identities
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - refactor-identities
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -8,23 +8,23 @@ on:
 
 jobs:
   build-and-push:
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@refactor-identities
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@v0.1.0
   security-scan:
     needs: [build-and-push]
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@refactor-identities
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@v0.1.0
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   policy-verification:
     needs:
       - build-and-push
       - security-scan
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@refactor-identities
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@v0.1.0
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   deploy:
     needs:
       - build-and-push
       - policy-verification
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@refactor-identities
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@v0.1.0
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}


### PR DESCRIPTION
Depends on the release of https://github.com/liatrio/gh-trusted-builds-workflows/pull/18