### PR TITLE
ci: bump workflows version

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -7,23 +7,23 @@ on:
 
 jobs:
   build-and-push:
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@v1.1.1
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@v1.1.2
   security-scan:
     needs: [build-and-push]
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@v1.1.1
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@v1.1.2
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   policy-verification:
     needs:
       - build-and-push
       - security-scan
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@v1.1.1
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@v1.1.2
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
   deploy:
     needs:
       - build-and-push
       - policy-verification
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@v1.1.1
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@v1.1.2
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}


### PR DESCRIPTION
Depends on the release of https://github.com/liatrio/gh-trusted-builds-workflows/pull/19