### PR TITLE
ci: update workflows to v2.0.0

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -15,6 +15,8 @@ jobs:
       contents: read
       packages: write
       pull-requests: read
+    with:
+      environment: pre-prod
   security-scan:
     needs: [ build-and-push ]
     uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@tuf-root-path
@@ -24,6 +26,7 @@ jobs:
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
+      environment: pre-prod
   policy-verification:
     needs:
       - build-and-push
@@ -35,6 +38,7 @@ jobs:
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
+      environment: pre-prod
   deploy:
     needs:
       - build-and-push
@@ -46,3 +50,4 @@ jobs:
       contents: read
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
+      environment: pre-prod

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -41,6 +41,7 @@ jobs:
       - policy-verification
     uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@tuf-root-path
     permissions:
+      id-token: write
       packages: read
       contents: read
     with:

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -3,11 +3,12 @@ on:
   push:
     branches:
       - main
+      - config
   workflow_dispatch:
 
 jobs:
   build-and-push:
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@v1.3.7
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@tuf-root-path
     permissions:
       actions: read
       id-token: write
@@ -16,7 +17,7 @@ jobs:
       pull-requests: read
   security-scan:
     needs: [ build-and-push ]
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@v1.3.7
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@tuf-root-path
     permissions:
       id-token: write
       contents: read
@@ -27,7 +28,7 @@ jobs:
     needs:
       - build-and-push
       - security-scan
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@v1.3.7
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@tuf-root-path
     permissions:
       id-token: write
       contents: read
@@ -38,7 +39,7 @@ jobs:
     needs:
       - build-and-push
       - policy-verification
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@v1.3.7
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@tuf-root-path
     permissions:
       packages: read
       contents: read

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -15,6 +15,8 @@ jobs:
       contents: read
       packages: write
       pull-requests: read
+    with:
+      environment: staging
   security-scan:
     needs: [ build-and-push ]
     uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@tuf-root-path
@@ -24,6 +26,7 @@ jobs:
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
+      environment: staging
   policy-verification:
     needs:
       - build-and-push
@@ -35,6 +38,7 @@ jobs:
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
+      environment: staging
   deploy:
     needs:
       - build-and-push
@@ -46,3 +50,4 @@ jobs:
       contents: read
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
+      environment: staging

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -15,8 +15,6 @@ jobs:
       contents: read
       packages: write
       pull-requests: read
-    with:
-      environment: staging
   security-scan:
     needs: [ build-and-push ]
     uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@tuf-root-path
@@ -26,7 +24,6 @@ jobs:
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
-      environment: staging
   policy-verification:
     needs:
       - build-and-push
@@ -38,7 +35,6 @@ jobs:
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
-      environment: staging
   deploy:
     needs:
       - build-and-push
@@ -50,4 +46,3 @@ jobs:
       contents: read
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
-      environment: staging

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -3,51 +3,45 @@ on:
   push:
     branches:
       - main
-      - config
   workflow_dispatch:
 
 jobs:
   build-and-push:
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@tuf-root-path
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@v2.0.0
     permissions:
       actions: read
       id-token: write
       contents: read
       packages: write
       pull-requests: read
-    with:
-      environment: pre-prod
   security-scan:
     needs: [ build-and-push ]
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@tuf-root-path
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@v2.0.0
     permissions:
       id-token: write
       contents: read
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
-      environment: pre-prod
   policy-verification:
     needs:
       - build-and-push
       - security-scan
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@tuf-root-path
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/policy-verification.yaml@v2.0.0
     permissions:
       id-token: write
       contents: read
       packages: write
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
-      environment: pre-prod
   deploy:
     needs:
       - build-and-push
       - policy-verification
-    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@tuf-root-path
+    uses: liatrio/gh-trusted-builds-workflows/.github/workflows/demo-deploy.yaml@v2.0.0
     permissions:
       id-token: write
       packages: read
       contents: read
     with:
       digest: ${{ needs.build-and-push.outputs.digest }}
-      environment: pre-prod


### PR DESCRIPTION
Depends on the release of https://github.com/liatrio/gh-trusted-builds-workflows/pull/49